### PR TITLE
Update vercel.json routing configuration

### DIFF
--- a/frontend/wordmaster/vercel.json
+++ b/frontend/wordmaster/vercel.json
@@ -2,10 +2,7 @@
   "version": 2,
   "rewrites": [
     { "source": "/api/(.*)", "destination": "http://3.26.165.228:8080/api/$1" },
-    { "source": "/actuator/(.*)", "destination": "http://3.26.165.228:8080/actuator/$1" }
-  ],
-  "routes": [
-    { "handle": "filesystem" },
-    { "src": "/.*", "dest": "/index.html" }
+    { "source": "/actuator/(.*)", "destination": "http://3.26.165.228:8080/actuator/$1" },
+    { "source": "/(.*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
Consolidated the 'routes' and 'rewrites' sections into a single 'rewrites' array and simplified the catch-all route to redirect all unmatched paths to /index.html. This streamlines the routing setup for the frontend deployment.