### PR TITLE
Update API rewrite to use HTTP instead of HTTPS

### DIFF
--- a/frontend/wordmaster/vercel.json
+++ b/frontend/wordmaster/vercel.json
@@ -12,7 +12,7 @@
     }
   ],
   "rewrites": [
-    { "source": "/api/(.*)", "destination": "https://3.26.165.228:8080/api/$1" },
+    { "source": "/api/(.*)", "destination": "http://3.26.165.228:8080/api/$1" },
     { "source": "/(.*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
Changed the Vercel rewrite rule for /api/* to use the HTTP protocol instead of HTTPS when proxying to the backend server.