### PR TITLE
Update API rewrite destination in vercel.json

### DIFF
--- a/frontend/wordmaster/vercel.json
+++ b/frontend/wordmaster/vercel.json
@@ -12,7 +12,7 @@
     }
   ],
   "rewrites": [
-    { "source": "/api/(.*)", "destination": "http://3.26.165.228:8080/api/$1" },
+    { "source": "/api/(.*)", "destination": "https://wordmaster.duckdns.org/api/$1" },
     { "source": "/(.*)", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
Changed the API rewrite destination from a direct IP address to the domain https://wordmaster.duckdns.org for improved maintainability and clarity.